### PR TITLE
Chore - Force SSL in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -38,7 +38,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.


### PR DESCRIPTION
Why: Browsers are moving to an https only web so we need to do this to avoid any warnings when accessed from browsers.