### PR TITLE
Feature - Add route for data sheet rendering

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,4 +36,5 @@ group :test do
   gem "rspec_junit_formatter"
   gem "rspec-rails"
   gem "factory_bot_rails"
+  gem "capybara"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,6 +59,14 @@ GEM
       msgpack (~> 1.0)
     builder (3.2.3)
     byebug (11.0.1)
+    capybara (3.16.1)
+      addressable
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (~> 1.2)
+      xpath (~> 3.2)
     case_transform (0.2)
       activesupport
     circuitdata (0.9.0)
@@ -155,6 +163,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
+    regexp_parser (1.4.0)
     rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
@@ -204,6 +213,8 @@ GEM
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
     will_paginate (3.1.7)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
 
 PLATFORMS
   ruby
@@ -214,6 +225,7 @@ DEPENDENCIES
   api-pagination
   bootsnap
   byebug
+  capybara
   circuitdata
   factory_bot_rails
   listen (~> 3.0.5)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,4 @@
-class ApplicationController < ActionController::API
+class ApplicationController < ActionController::Base
   rescue_from ActionController::UnpermittedParameters, with: :unpermitted_parameters_rescue
 
   def unpermitted_parameters_rescue(exception)

--- a/app/controllers/materials_controller.rb
+++ b/app/controllers/materials_controller.rb
@@ -12,7 +12,22 @@ class MaterialsController < ApplicationController
     render json: materials
   end
 
+  def datasheet
+    @material = Material.find(params[:id])
+    sheet = @material.datasheet
+    return send_sheet(sheet) if sheet.exist?
+  end
+
   private
+
+  def send_sheet(sheet)
+    send_data(
+      sheet.contents.read,
+      filename: sheet.filename,
+      type: "application/pdf",
+      disposition: "inline",
+    )
+  end
 
   def search_params
     params.permit(:name, :link)

--- a/app/views/materials/datasheet.html.erb
+++ b/app/views/materials/datasheet.html.erb
@@ -1,0 +1,5 @@
+<h1>No datasheet available.</h1>
+<% if @material.link.present? %>
+<p>It may be available at: <%= link_to @material.link, @material.link %></p>
+<% end %>
+<p>If the datasheet is available let us know!</p>

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,7 +8,7 @@ require "active_record/railtie"
 # require "active_storage/engine"
 require "action_controller/railtie"
 # require "action_mailer/railtie"
-# require "action_view/railtie"
+require "action_view/railtie"
 # require "action_cable/engine"
 # require "sprockets/railtie"
 # require "rails/test_unit/railtie"
@@ -33,7 +33,7 @@ module Circuitdatamaterials
     # Only loads a smaller set of middleware suitable for API only apps.
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
-    config.api_only = true
+    # config.api_only = true
     # use uuid as primary key
     config.generators do |g|
       g.orm :active_record, primary_key_type: :uuid

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,9 @@
 Rails.application.routes.draw do
-  resources :materials, only: [:index, :show]
+  resources :materials, only: [:index, :show] do
+    member do
+      get :datasheet
+    end
+  end
   resources :manufacturers, only: [:index, :show]
   # To capture routing error and display error message without trace
   match "*path", :to => "application#routing_error", via: [:get]

--- a/lib/datasheet.rb
+++ b/lib/datasheet.rb
@@ -4,7 +4,7 @@ class Datasheet
   end
 
   def exist?
-    File.exist?(file_path)
+    material.manufacturer_name.present? && File.exist?(file_path)
   end
 
   def file_path
@@ -12,8 +12,16 @@ class Datasheet
       "lib",
       "datasheets",
       clean(material.manufacturer_name),
-      "#{clean(material.name)}.pdf"
+      filename
     )
+  end
+
+  def contents
+    File.open(file_path, "rb")
+  end
+
+  def filename
+    @filename ||= "#{clean(material.name)}.pdf"
   end
 
   private

--- a/spec/features/datasheet_download_spec.rb
+++ b/spec/features/datasheet_download_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe "Datasheet download" do
+  let(:manufacturer) { create(:manufacturer, name: "arlon") }
+  let(:material) {
+    create(
+      :material,
+      manufacturer: manufacturer,
+      name: material_name,
+      link: "http://example.com",
+    )
+  }
+
+  context "datasheet is present" do
+    let(:material_name) { "47n" }
+
+    scenario "the datasheet can be downloaded" do
+      visit datasheet_material_path(material)
+      expect(page.body).not_to be_empty
+      expect(page.body).to start_with("%PDF-1.6")
+    end
+  end
+
+  context "datasheet is not present" do
+    let(:material_name) { "not a real one" }
+
+    scenario "a message is displayed" do
+      visit datasheet_material_path(material)
+
+      expect(page).to have_content("No datasheet available.")
+      expect(page).to have_content("It may be available at: http://example.com")
+      expect(page).to have_content("If the datasheet is available let us know!")
+    end
+  end
+end


### PR DESCRIPTION
Why: So that it can be linked to from other applications.

Also converts the app from API only so that we can render a html error message when the datasheet is not available.

<img width="832" alt="Screenshot 2019-04-03 at 13 22 20" src="https://user-images.githubusercontent.com/1177034/55475216-97a43800-5613-11e9-9d05-7c962328cd17.png">
