### PR TITLE
Chore - Remove null attributes from serializers

### DIFF
--- a/app/serializers/application_serializer.rb
+++ b/app/serializers/application_serializer.rb
@@ -1,0 +1,7 @@
+class ApplicationSerializer < ActiveModel::Serializer
+  def serializable_hash(adapter_options = nil, options = {}, adapter_instance = self.class.serialization_adapter_instance)
+    hash = super
+    hash.each { |key, value| hash.delete(key) if value.nil? }
+    hash
+  end
+end

--- a/app/serializers/manu_serializer.rb
+++ b/app/serializers/manu_serializer.rb
@@ -1,3 +1,3 @@
-class ManuSerializer < ActiveModel::Serializer
+class ManuSerializer < ApplicationSerializer
   attributes :name, :verified, :description, :location, :ul, :ul_c
 end

--- a/app/serializers/manufacture_material_serializer.rb
+++ b/app/serializers/manufacture_material_serializer.rb
@@ -1,3 +1,3 @@
-class ManufactureMaterialSerializer < ActiveModel::Serializer
+class ManufactureMaterialSerializer < ApplicationSerializer
   attributes :name, :function, :group, :flexible, :additional, :link, :remark, :ul_94, :accept_equivalent
 end

--- a/app/serializers/manufacturer_serializer.rb
+++ b/app/serializers/manufacturer_serializer.rb
@@ -1,4 +1,4 @@
-class ManufacturerSerializer < ActiveModel::Serializer
+class ManufacturerSerializer < ApplicationSerializer
   attributes :name, :verified, :source, :source_id, :description, :location, :ul, :ul_c, :materials
 
   def materials

--- a/app/serializers/material_attribute_serializer.rb
+++ b/app/serializers/material_attribute_serializer.rb
@@ -1,4 +1,4 @@
-class MaterialAttributeSerializer < ActiveModel::Serializer
+class MaterialAttributeSerializer < ApplicationSerializer
   attributes(
     :ipc_standard,
     :cti,

--- a/app/serializers/material_serializer.rb
+++ b/app/serializers/material_serializer.rb
@@ -1,4 +1,4 @@
-class MaterialSerializer < ActiveModel::Serializer
+class MaterialSerializer < ApplicationSerializer
   attributes(
     :version,
     :circuitdata_material_db_id,

--- a/spec/requests/materials_spec.rb
+++ b/spec/requests/materials_spec.rb
@@ -113,4 +113,16 @@ RSpec.describe "/materials" do
     validator.valid?
     expect(validator.errors).to eql([])
   end
+
+  context "material has minimal attributes" do
+    let!(:material) { create(:material) }
+    it "returns valid circuitdata materials" do
+      get "/materials"
+
+      parsed_data = JSON.parse(response.body, symbolize_names: true)
+      validator = Circuitdata::MaterialValidator.new(parsed_data.first)
+      validator.valid?
+      expect(validator.errors).to eql([])
+    end
+  end
 end

--- a/spec/serializers/material_attribute_serializer_spec.rb
+++ b/spec/serializers/material_attribute_serializer_spec.rb
@@ -5,6 +5,6 @@ RSpec.describe MaterialAttributeSerializer do
   let(:material) { create(:material, cti: nil) }
 
   it "does not convert cti to zero" do
-    expect(subject.as_json.fetch(:cti)).to be(nil)
+    expect(subject.as_json).not_to have_key(:cti)
   end
 end

--- a/spec/serializers/material_serializer_spec.rb
+++ b/spec/serializers/material_serializer_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.describe MaterialSerializer do
+  subject { described_class.new(material) }
+  let(:material) { create(:material) }
+
+  it "serializes valid materials" do
+    parsed_data = JSON.parse(subject.to_json, symbolize_names: true)
+    validator = Circuitdata::MaterialValidator.new(parsed_data)
+    validator.valid?
+    expect(validator.errors).to eql([])
+  end
+end


### PR DESCRIPTION
Why: Null attributes are not supported in the schema.