### PR TITLE
Chore - Upgrade material version to 2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem "will_paginate", "~> 3.1.0"
 gem "api-pagination"
 gem "active_model_serializers", "~> 0.10.2"
 gem "rack-attack"
-gem "circuitdata"
+gem "circuitdata", github: 'Elmatica/circuit-data-gem'
 gem "active_record_upsert"
 gem "bootstrap", "~> 4.3.1"
 gem "jquery-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,12 @@
+GIT
+  remote: https://github.com/Elmatica/circuit-data-gem.git
+  revision: 1f41eacb12976a04b4b7855d48a5c42a0b41d0ce
+  specs:
+    circuitdata (0.9.0)
+      activesupport (~> 5.1)
+      json-schema (= 2.8.0)
+      terminal-table (~> 1.8.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -76,10 +85,6 @@ GEM
       xpath (~> 3.2)
     case_transform (0.2)
       activesupport
-    circuitdata (0.9.0)
-      activesupport (~> 5.1)
-      json-schema (= 2.8.0)
-      terminal-table (~> 1.8.0)
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
     crass (1.0.4)
@@ -271,7 +276,7 @@ DEPENDENCIES
   bootstrap (~> 4.3.1)
   byebug
   capybara
-  circuitdata
+  circuitdata!
   factory_bot_rails
   jquery-rails
   listen (>= 3.0.5, < 3.2)

--- a/app/serializers/material_serializer.rb
+++ b/app/serializers/material_serializer.rb
@@ -30,6 +30,6 @@ class MaterialSerializer < ApplicationSerializer
   end
 
   def version
-    1.0
+    2.0
   end
 end

--- a/spec/requests/materials_spec.rb
+++ b/spec/requests/materials_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe "/api/v1/materials" do
       flexible: true,
       function: "final_finish",
       group: "FR2",
-      version: 1.0,
+      version: 2.0,
     })
     expect(mat[:attributes]).to eql(
       ipc_standard: 12,


### PR DESCRIPTION
Why: So it is consistent with the latest schema version.