### PR TITLE
Chore - Pin sprockets version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem "jquery-rails"
 gem "turbolinks"
 gem "bootsnap", require: false
 gem "pagy"
+gem "sprockets", "< 4.0"
 
 group :development, :test do
   gem "byebug", platform: :mri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -295,6 +295,7 @@ DEPENDENCIES
   sass-rails
   spring
   spring-watcher-listen (~> 2.0.0)
+  sprockets (< 4.0)
   turbolinks
   uglifier
   web-console


### PR DESCRIPTION
Why: 4.0 is a breaking change.